### PR TITLE
SpacePy updates for current HelioCloud environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 
 astropy >= 1.0
 plasmapy >= 2024.2.0
-spacepy >=0.5.0
+spacepy >=0.6.0

--- a/spacepy-tutorial/SpacePy - Cusp energetic particles.md
+++ b/spacepy-tutorial/SpacePy - Cusp energetic particles.md
@@ -15,6 +15,8 @@ jupyter:
 # SpacePy Tutorial -- Cusp Energetic Particles
 This tutorial reproduces key figures from "Association of cusp energetic ions with geomagnetic storms and substorms" (Niehof et al, 2012; [doi:10.5194/angeo-30-1633-2012](https://doi.org/10.5194/angeo-30-1633-2012)).
 
+This Markdown-formatted notebook uses Jupytext; if you are seeing Markdown source or a rendered document without "live" Jupyter notebook cells, open as a notebook (e.g. in JupyterLab, right-click, "Open With", "Notebook").
+
 It illustrates several functions in SpacePy and the scientific Python ecosystem:
 
   - Import of IDL data [scipy.io](https://docs.scipy.org/doc/scipy/reference/generated/scipy.io.readsav.html#scipy.io.readsav)

--- a/spacepy-tutorial/SpacePy - Cusp energetic particles.md
+++ b/spacepy-tutorial/SpacePy - Cusp energetic particles.md
@@ -38,7 +38,7 @@ So we use a single directory containing all the data for this tutorial and also 
 
 ```python
 # Only use this if participating in the summer school!
-tutorial_data = '/shared/jtniehof/spacepy_tutorial'  # All data for this summer school, will be used throughout
+tutorial_data = '/home/jovyan/scratch_space/spacepy_tutorial'  # All data for this summer school, will be used throughout
 import os
 os.environ['SPACEPY'] = tutorial_data  # Use .spacepy directory inside this directory
 ```

--- a/spacepy-tutorial/SpacePy - Cusp energetic particles.md
+++ b/spacepy-tutorial/SpacePy - Cusp energetic particles.md
@@ -71,7 +71,7 @@ Download the [sample data for this notebook](https://doi.org/10.5281/zenodo.1090
 # Download high-res omni
 #hro_base = os.path.join(tutorial_data, 'hro')
 #spacepy.toolbox._crawl_yearly('https://spdf.gsfc.nasa.gov/pub/data/omni/omni_cdaweb/hro_5min/',
-                              r'omni_hro_5min_(199\d|200[012])[01]\d01_v01.cdf', hro_base, startyear=1996)
+#                              r'omni_hro_5min_(199\d|200[012])[01]\d01_v01.cdf', hro_base, startyear=1996)
 ```
 
 ## Background

--- a/spacepy-tutorial/SpacePy - Cutoff Rigidities.md
+++ b/spacepy-tutorial/SpacePy - Cutoff Rigidities.md
@@ -596,7 +596,7 @@ for idx, mm in enumerate(moments):
 
 fig = plt.figure()
 ax = fig.add_subplot(111)
-ax.plot(epochs.UTC, cutoffs)
+ax.plot(epochs.UTC, cutoffs, ls='--')
 ax = plt.gca()
 ax2 = ax.twinx()
 ax2.grid(False)

--- a/spacepy-tutorial/SpacePy - Cutoff Rigidities.md
+++ b/spacepy-tutorial/SpacePy - Cutoff Rigidities.md
@@ -17,6 +17,8 @@ jupyter:
 ### Background
 Earth's magnetic field provides protection from high energy charged particles originating outside the magnetosphere, such as solar energetic particles (SEPs) and galactic cosmic rays (GCRs). Properties of both the particle (mass, energy, charge) and the magnetic field (strength, topology)  will determine how deep into the magnetosphere a particle can penetrate.
 
+This Markdown-formatted notebook uses Jupytext; if you are seeing Markdown source or a rendered document without "live" Jupyter notebook cells, open as a notebook (e.g. in JupyterLab, right-click, "Open With", "Notebook").
+
 This example is largely inspired by ([Smart and Shea, 1993](https://adsabs.harvard.edu/full/1993ICRC....3..781S)), especially their Figure 2. It will also present the energetic charged particle data from the Global Positioning System constellation ([Morley et al., 2017](https://doi.org/10.1002/2017SW001604)).
 
 It illustrates several areas of functionality in SpacePy and the broader scientific Python ecosystem, as well as some approaches less widely used in academic programming, including:

--- a/spacepy-tutorial/SpacePy - Cutoff Rigidities.md
+++ b/spacepy-tutorial/SpacePy - Cutoff Rigidities.md
@@ -44,7 +44,7 @@ is_pyhc = True
 import os
 import matplotlib
 if is_pyhc:
-    tutorial_data = '/shared/jtniehof/spacepy_tutorial'  # All data for Python in Heliophysics summer school
+    tutorial_data = '/home/jovyan/scratch_space/spacepy_tutorial'  # All data for Python in Heliophysics summer school
     os.environ['SPACEPY'] = tutorial_data  # Use .spacepy directory inside this directory
 else:
     tutorial_data = os.path.expanduser('~/spacepy_tutorial')  # Point this to wherever you want data to go.

--- a/spacepy-tutorial/SpacePy - MMS Ephemeris.md
+++ b/spacepy-tutorial/SpacePy - MMS Ephemeris.md
@@ -18,6 +18,8 @@ NASA's Magnetospheric Multiscale (MMS) mission includes a slightly unusual instr
 
 This tutorial introduces a few key tools and techniques in the SpacePy and scientific Python ecosystem through illustrative use on MMS data.
 
+This Markdown-formatted notebook uses Jupytext; if you are seeing Markdown source or a rendered document without "live" Jupyter notebook cells, open as a notebook (e.g. in JupyterLab, right-click, "Open With", "Notebook").
+
 *We note that MEC files with a major version number of 1 (i.e. v1.x.x) give the quaternions to rotate the frame.
 MEC files with a major version number of >=2 (i.e. 2.x.x) give the quaternion to rotate the vector.*
 

--- a/spacepy-tutorial/SpacePy - MMS Ephemeris.md
+++ b/spacepy-tutorial/SpacePy - MMS Ephemeris.md
@@ -104,7 +104,7 @@ for key, value in mmsdata['mms1_mec_quat_eci_to_gse'].attrs.items():
 The [plot](https://spacepy.github.io/autosummary/spacepy.datamodel.ISTPContainer.html#spacepy.datamodel.ISTPContainer.plot) method of SpaceData allows for some quick and easy plots of the variables:
 
 ```python
-fig = mmsdata.plot(["mms1_mec_kp", "mms1_mec_v_gse"])
+fig = mmsdata.plot(["mms1_mec_dst", "mms1_mec_r_gse", "mms1_mec_v_gse"])
 ```
 
 ### So how do we use these quaternions?

--- a/spacepy-tutorial/SpacePy - MMS Ephemeris.md
+++ b/spacepy-tutorial/SpacePy - MMS Ephemeris.md
@@ -35,7 +35,7 @@ import os
 # If no, make sure it's set to `False`
 is_pyhc = True
 if is_pyhc:
-    tutorial_data = '/shared/jtniehof/spacepy_tutorial'  # All data for Python in Heliophysics summer school
+    tutorial_data = '/home/jovyan/scratch_space/spacepy_tutorial'  # All data for Python in Heliophysics summer school
     os.environ['SPACEPY'] = tutorial_data  # Use .spacepy directory inside this directory
 else:
     tutorial_data = os.path.expanduser('~/spacepy_tutorial')  # Point this to wherever you want data to go.

--- a/spacepy-tutorial/SpacePy - SWMF Dynamics.md
+++ b/spacepy-tutorial/SpacePy - SWMF Dynamics.md
@@ -19,7 +19,7 @@ jupyter:
 
 This tutorial was created for the [Python in Heliophysics Community (PyHC) 2022 Summer School](https://heliopython.org/summer-school). [Video of the original tutorial can be found here.](https://youtu.be/vHlOI6JAZ7A?t=19533) Commands relevant to the PyHC Summer School environment are commented out and in separate cells.
 
-Ensure that Spacepy is properly installed before running this Jupyter notebook.
+Ensure that Spacepy is properly installed before running this Jupyter notebook. This Markdown-formatted notebook uses Jupytext; if you are seeing Markdown source or a rendered document without "live" Jupyter notebook cells, open as a notebook (e.g. in JupyterLab, right-click, "Open With", "Notebook").
 
 The data that accompanies this tutorial has been archieved at Zenodo.com with the following DOI: 10.5281/zenodo.7693203. 
 [Users may download the data here.](https://doi.org/10.5281/zenodo.7693203)

--- a/spacepy-tutorial/SpacePy - SWMF Dynamics.md
+++ b/spacepy-tutorial/SpacePy - SWMF Dynamics.md
@@ -52,7 +52,7 @@ As is the case for the other Spacepy tutorials, we use a single directory contai
 
 ```python
 # Only use this if participating in the summer school!
-tutorial_data = '/shared/jtniehof/spacepy_tutorial/'  #All data for this tutorial, will be used throughout.
+tutorial_data = '/home/jovyan/scratch_space/spacepy_tutorial/'  #All data for this tutorial, will be used throughout.
 import os
 os.environ['SPACEPY'] = tutorial_data
 ```


### PR DESCRIPTION
This is the equivalent of spacepy/examples#3:

- The data location has changed from 2022
- People have been opening the notebooks in MD editor or preview, so there's an explicit note "open this as a notebook"
- Switch one MMS ephemeris example to variables that plot properly in 0.6.0, to work around spacepy/spacepy#741 so we don't need to roll out a new release before the summer school
- Cutoff rigidities was doing some overplots where you couldn't distinguish between two lines of the same colour, so made one of them dashed
- Unique to this PR (not in spacepy/examples#3): update requirements.txt for spacepy 0.6.0 instead of 0.5.0.

With these updates, all the notebooks run on the summer school HC instance.